### PR TITLE
Handle marker_bed and marker_txt as files

### DIFF
--- a/modules/conpairContamination.nf
+++ b/modules/conpairContamination.nf
@@ -1,6 +1,7 @@
 process conpairContamination {
     input:
     tuple val(match_normal_id), path(match_pileup), val(sample_id), path(sample_pileup)
+    path(marker_txt)
 
     output:
     path(contamination_path)
@@ -8,7 +9,7 @@ process conpairContamination {
     script:
     contamination_path = "${sample_id}_${match_normal_id}.contamination.txt"
     """
-    estimate_tumor_normal_contamination.py -T ${sample_pileup} -N ${match_pileup} -M ${params.marker_txt} -O ${contamination_path}
+    estimate_tumor_normal_contamination.py -T ${sample_pileup} -N ${match_pileup} -M ${marker_txt} -O ${contamination_path}
     """
 
 }

--- a/modules/conpairPileup.nf
+++ b/modules/conpairPileup.nf
@@ -3,6 +3,7 @@ process conpairPileup {
 
     input:
     tuple val(match_normal_id), val(sample_id), path(bam), path(bai)
+    path(marker_bed)
 
     output:
     tuple val(match_normal_id), val(sample_id), path(pileup)
@@ -10,7 +11,7 @@ process conpairPileup {
     script:
     pileup = "${sample_id}.pileup"
     """
-    gatk --java-options -Xmx10g Pileup -R ${params.reference_genome} -I ${bam} -L ${params.marker_bed} -O ${pileup} -verbose -RF NotDuplicateReadFilter -RF CigarContainsNoNOperator -RF MatchingBasesAndQualsReadFilter
+    gatk --java-options -Xmx10g Pileup -R ${params.reference_genome} -I ${bam} -L ${marker_bed} -O ${pileup} -verbose -RF NotDuplicateReadFilter -RF CigarContainsNoNOperator -RF MatchingBasesAndQualsReadFilter
     """
 
 }

--- a/modules/verifyConcordance.nf
+++ b/modules/verifyConcordance.nf
@@ -1,6 +1,7 @@
 process verifyConcordance {
     input:
     tuple val(sample_id), path(sample_pileup), val(match_normal_id), path(match_pileup)
+    path(marker_txt)
 
     output:
     path(concordance_path)
@@ -9,6 +10,6 @@ process verifyConcordance {
     concordance_path = "${sample_id}_${match_normal_id}.concordance.txt"
     
     """
-    verify_concordance.py -T ${sample_pileup} -N ${match_pileup} -M ${params.marker_txt} -O ${concordance_path}
+    verify_concordance.py -T ${sample_pileup} -N ${match_pileup} -M ${marker_txt} -O ${concordance_path}
     """
 }

--- a/workflows/conpair_filter_with_match_normal.nf
+++ b/workflows/conpair_filter_with_match_normal.nf
@@ -11,29 +11,33 @@ workflow CONPAIR_FILTER_WITH_MATCH_NORMAL {
     main:
     sample_paths = new File(sample_paths).getText('UTF-8')
 
+    // marker reference files
+    marker_txt = file(params.marker_txt, checkIfExists: true)
+    marker_bed = file(params.marker_bed, checkIfExists: true)
+
     // pileup
     // sample
     sample_pileup_input_ch = Channel.of(sample_paths)
             .splitCsv( header: true, sep : '\t' )
             .map { row -> tuple( row.match_normal_id, row.sample_id, row.bam, row.bai ) }
-    pileup_sample = conpairPileupSample(sample_pileup_input_ch)
+    pileup_sample = conpairPileupSample(sample_pileup_input_ch, marker_bed)
     // normal
     match_pileup_input_ch = Channel.of(sample_paths)
             .splitCsv( header: true, sep : '\t' )
             .map { row -> tuple( row.match_normal_id, row.match_normal_id, row.bam_match, row.bai_match ) }
             .unique()
-    pileup_match = conpairPileupMatch(match_pileup_input_ch)
+    pileup_match = conpairPileupMatch(match_pileup_input_ch, marker_bed)
 
     // Concordance between sample and match normal
     concordance_input_ch = pileup_sample.combine(pileup_match)
         .map { sample -> tuple(sample[1], sample[2], sample[3], sample[5]) }
-    concordance_output_ch = verifyConcordance(concordance_input_ch)
+    concordance_output_ch = verifyConcordance(concordance_input_ch, marker_txt)
         .collectFile( name: 'conpair_out/concordance.txt', newLine: true )
 
     // Contamination 
     contamination_input_ch = pileup_match.cross(pileup_sample)
         .map { sample -> tuple(sample[0][0], sample[0][2], sample[1][1], sample[1][2]) }
-    contamination_output_ch = conpairContamination(contamination_input_ch)
+    contamination_output_ch = conpairContamination(contamination_input_ch, marker_txt)
         .collectFile( name: 'conpair_out/contamination.txt', newLine: true )
 
     // Filtering contamination based on concordance and contamination


### PR DESCRIPTION
Make marker_txt and marker_bed into file objects rather than passing path params straight into conpair processes